### PR TITLE
Add ftplugin

### DIFF
--- a/ftplugin/solidity.vim
+++ b/ftplugin/solidity.vim
@@ -1,0 +1,4 @@
+setlocal commentstring=//\ %s
+setlocal expandtab
+setlocal tabstop=4
+setlocal shiftwidth=4


### PR DESCRIPTION
This causes vim to use whitespacing settings that are in line with the
official style guide.