### PR TITLE
Change ftplugin to not overwrite user settings

### DIFF
--- a/ftplugin/solidity.vim
+++ b/ftplugin/solidity.vim
@@ -1,4 +1,1 @@
 setlocal commentstring=//\ %s
-setlocal expandtab
-setlocal tabstop=4
-setlocal shiftwidth=4


### PR DESCRIPTION
This change removes code that overwrites user settings for expandtab, tabstop and softtabstop.

This has been criticised in https://github.com/tomlion/vim-solidity/issues/16