### PR TITLE
added constructor as word to be highlighted

### DIFF
--- a/syntax/solidity.vim
+++ b/syntax/solidity.vim
@@ -9,7 +9,7 @@ endif
 
 " basic
 " contract, library and event are defined at bottom of file
-syn keyword solKeyword           abstract anonymous as assembly break case catch constant continue default
+syn keyword solKeyword           abstract anonymous as assembly break case catch constant constructor continue default
 syn keyword solKeyword           delete do else emit enum external final for function if import in indexed inline
 syn keyword solKeyword           interface internal is let match memory modifier new of payable pragma private public pure
 syn keyword solKeyword           relocatable require return returns static storage struct throw try type typeof using


### PR DESCRIPTION
recent change in the constructor definition (e.g. current version http://solidity.readthedocs.io/en/v0.4.23/contracts.html)