### PR TITLE
Improve handling of comments and doc comments

### DIFF
--- a/ftplugin/solidity.vim
+++ b/ftplugin/solidity.vim
@@ -1,1 +1,3 @@
 setlocal commentstring=//\ %s
+setlocal comments=s1:/*,mb:*,ex:*/,:///,://
+setlocal formatoptions+=croqn


### PR DESCRIPTION
Doc comments are now properly formatted with `gq` and `J`. For example,
on this input text:

```
/// one
/// two
```

pressing `J` on the top line used to result in `/// one / two`, and now
results in `/// one two`. Conversely, on this input text:

```
/// this long line exceeds the text width
```

pressing `gqgq` with a `textwidth` of 20 now yields:

```
/// this long line
/// exceeds the text
/// width
```

instead of:

```
/// this long line
//exceeds the text
//width
```

Furthermore, adding a new line to an existing comment, by pressing `o`
in normal mode or `Enter` in insert mode, now automatically inserts the
appropriate comment leader (`//` or `///`).

wchargin-branch: comment-doc-and-leader
